### PR TITLE
include string.h. fix below compile error with strchr.

### DIFF
--- a/src/mrb_base64.c
+++ b/src/mrb_base64.c
@@ -1,5 +1,6 @@
 #include <mruby.h>
 #include <mruby/string.h>
+#include <string.h>
 #include <strings.h>
 #include <ctype.h>
 


### PR DESCRIPTION
src/mrb_base64.c:74: error: implicit declaration of function ‘strchr’
