### PR TITLE
Fix to use assert_equal explicitly

### DIFF
--- a/test/base64.rb
+++ b/test/base64.rb
@@ -1,12 +1,12 @@
 
 assert('Base64 encode "ruby"') do
-  Base64::encode('ruby') == 'cnVieQ=='
+  assert_equal 'cnVieQ==', Base64::encode('ruby')
 end
 
 assert('Base64 decode for old example') do
-  Base64::decode('44GK5YmN44Gv44Gp44GT44Gu44Ov44Kr44Oh44GY44KD') == "お前はどこのワカメじゃ"
+  assert_equal "お前はどこのワカメじゃ", Base64::decode('44GK5YmN44Gv44Gp44GT44Gu44Ov44Kr44Oh44GY44KD')
 end
 
 assert('Base64 decode null characters') do
-  Base64::decode('AGZvbw==') == "\000foo"
+  assert_equal "\000foo", Base64::decode('AGZvbw==')
 end


### PR DESCRIPTION
To work well with recent mruby test/assert.rb (see https://github.com/mruby/mruby/pull/3380).
The current style test codes don't work well completely (passes without failure even when it returns false).