### PR TITLE
Fix to ignore newlines in encoded data

### DIFF
--- a/src/mrb_base64.c
+++ b/src/mrb_base64.c
@@ -16,6 +16,10 @@ const char* base64_chars =
     ((unsigned char)c == '+') || \
     ((unsigned char)c == '/'))
 
+#define is_newline(c) ( \
+    ((unsigned char)c == '\n') || \
+    ((unsigned char)c == '\r'))
+
 unsigned char*
 base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len, unsigned int *out_len) {
   int i = 0;
@@ -72,8 +76,10 @@ base64_decode(unsigned char const* bytes_to_decode, unsigned int in_len, unsigne
   unsigned char* p = malloc(in_len * 3 + 1);
   unsigned char* top = p;
   *out_len = 0;
-  while (in_len-- && ( bytes_to_decode[in_] != '=') && is_base64(bytes_to_decode[in_])) {
-    char_array_4[i++] = bytes_to_decode[in_]; in_++;
+  while (in_len-- && ( bytes_to_decode[in_] != '=') && (is_base64(bytes_to_decode[in_]) || is_newline(bytes_to_decode[in_]))) {
+    if (!is_newline(bytes_to_decode[in_]))
+      char_array_4[i++] = bytes_to_decode[in_];
+    in_++;
     if (i ==4) {
       for (i = 0; i <4; i++)
         char_array_4[i] = strchr(base64_chars, char_array_4[i]) - base64_chars;

--- a/test/base64.rb
+++ b/test/base64.rb
@@ -10,3 +10,14 @@ end
 assert('Base64 decode null characters') do
   assert_equal "\000foo", Base64::decode('AGZvbw==')
 end
+
+assert('Base64 decode for data including newlines') do
+  json = '{"key_field_first": "key_field_first", "key_field_second": "key_field_second", "attribute_one": "attribute_one", "attribute_two": "attribute_two", "path": "/path/of/example/handler", "method": "GET"}'
+  # Base64.encode64(json) #=> data # on MRI
+  data = "eyJrZXlfZmllbGRfZmlyc3QiOiAia2V5X2ZpZWxkX2ZpcnN0IiwgImtleV9m\n" +
+    "aWVsZF9zZWNvbmQiOiAia2V5X2ZpZWxkX3NlY29uZCIsICJhdHRyaWJ1dGVf\n" +
+    "b25lIjogImF0dHJpYnV0ZV9vbmUiLCAiYXR0cmlidXRlX3R3byI6ICJhdHRy\n" +
+    "aWJ1dGVfdHdvIiwgInBhdGgiOiAiL3BhdGgvb2YvZXhhbXBsZS9oYW5kbGVy\n" +
+    "IiwgIm1ldGhvZCI6ICJHRVQifQ==\n"
+  assert_equal json, Base64::decode(data)
+end


### PR DESCRIPTION
This change is to ignore newline chars in decoded string.

According to [RFC4648](https://tools.ietf.org/html/rfc4648#section-3.3), this is a kind of optional behavior.
But MRI's Base64 library generates strings including newlines, and currently, this mrbgem's `Base64.decode` stops decoding at the newline chars (without errors).

This change will improve the inter-operability of Base64 encoding/decoding between MRI and mruby.
@mattn How do you feel about this change?